### PR TITLE
chore: fix namespace packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ ch-maketable = "CombineHarvester.CombineTools.maketable:main"
 
 [tool.setuptools]
 packages = [
-    "CombineHarvester",
     "CombineHarvester.CombineTools",
     "CombineHarvester.CombineTools.combine",
     "CombineHarvester.CombineTools.systematics",
@@ -32,15 +31,14 @@ packages = [
 ]
 
 [tool.setuptools.package-dir]
-"CombineHarvester" = "CombineHarvester"
-"CombineHarvester.CombineTools" = "CombineHarvester/CombineTools/python"
-"CombineHarvester.CombineTools.combine" = "CombineHarvester/CombineTools/python/combine"
-"CombineHarvester.CombineTools.systematics" = "CombineHarvester/CombineTools/python/systematics"
-"CombineHarvester.CombineTools.scripts" = "CombineHarvester/CombineTools/scripts"
-"CombineHarvester.CombineTools.input" = "CombineHarvester/CombineTools/input"
-"CombineHarvester.CombineTools.input.examples" = "CombineHarvester/CombineTools/input/examples"
-"CombineHarvester.CombineTools.input.job_prefixes" = "CombineHarvester/CombineTools/input/job_prefixes"
-"CombineHarvester.CombineTools.input.xsecs_brs" = "CombineHarvester/CombineTools/input/xsecs_brs"
+"CombineHarvester.CombineTools" = "CombineTools/python"
+"CombineHarvester.CombineTools.combine" = "CombineTools/python/combine"
+"CombineHarvester.CombineTools.systematics" = "CombineTools/python/systematics"
+"CombineHarvester.CombineTools.scripts" = "CombineTools/scripts"
+"CombineHarvester.CombineTools.input" = "CombineTools/input"
+"CombineHarvester.CombineTools.input.examples" = "CombineTools/input/examples"
+"CombineHarvester.CombineTools.input.job_prefixes" = "CombineTools/input/job_prefixes"
+"CombineHarvester.CombineTools.input.xsecs_brs" = "CombineTools/input/xsecs_brs"
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]


### PR DESCRIPTION
## Summary
- remove top-level `CombineHarvester` package
- update package paths for namespace packaging

## Testing
- `python setup.py egg_info` *(fails: ModuleNotFoundError: No module named 'setuptools')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7df789448329bd65e5ffd114cf03