### PR TITLE
Build CombineTools via CMake during setup

### DIFF
--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -25,7 +25,10 @@ target_include_directories(CombineTools
     ${_CL_INC}
 )
 target_link_libraries(CombineTools PUBLIC ${CH_EXTERNAL_LIBS} HiggsAnalysisCombinedLimit::HiggsAnalysisCombinedLimit)
-set_target_properties(CombineTools PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(CombineTools PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  OUTPUT_NAME CombineHarvesterCombineTools
+)
 
 file(GLOB COMBINE_TOOLS_BINS CONFIGURE_DEPENDS bin/*.cpp)
 set(COMBINE_TOOLS_BINARIES)

--- a/CombineTools/python/ch.py
+++ b/CombineTools/python/ch.py
@@ -9,12 +9,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 import itertools
 from os import environ
+from importlib import resources
+import sys
 
 # Prevent cppyy's check for the PCH
 environ['CLING_STANDARD_PCH'] = 'none'
 import cppyy
 
-cppyy.load_reflection_info("libCombineHarvesterCombineTools")
+suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
+lib_path = resources.files(__package__) / f"libCombineHarvesterCombineTools{suffix}"
+cppyy.load_reflection_info(str(lib_path))
 AutoRebin = cppyy.gbl.ch.AutoRebin
 BinByBinFactory = cppyy.gbl.ch.BinByBinFactory
 CardWriter = cppyy.gbl.ch.CardWriter

--- a/setup.py
+++ b/setup.py
@@ -3,24 +3,40 @@ import sys
 import shutil
 from pathlib import Path
 
-from setuptools import setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 
+class CMakeExtension(Extension):
+    def __init__(self, name: str) -> None:
+        super().__init__(name, sources=[])
+
+
 class CMakeBuild(build_ext):
-    def run(self):
-        super().run()
+    def build_extension(self, ext: Extension) -> None:  # noqa: D401 - see base class
         build_temp = Path(self.build_temp)
         build_temp.mkdir(parents=True, exist_ok=True)
         source_dir = Path(__file__).resolve().parent
         subprocess.check_call(["cmake", "-S", str(source_dir), "-B", str(build_temp)])
         subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
+
         suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
-        dest_tools = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
-        dest_tools.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(build_temp / "CombineTools" / f"libCombineTools{suffix}",
-                     dest_tools / f"libCombineHarvesterCombineTools{suffix}")
+        lib_name = f"libCombineHarvesterCombineTools{suffix}"
+        built_lib = build_temp / "CombineTools" / lib_name
+
+        # Copy into the package source for editable installs
+        pkg_dir = source_dir / "CombineTools" / "python"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(built_lib, pkg_dir / lib_name)
+
+        # Ensure the library is also available in the build directory
+        dest_dir = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(built_lib, dest_dir / lib_name)
 
 
-setup(cmdclass={"build_ext": CMakeBuild})
+setup(
+    cmdclass={"build_ext": CMakeBuild},
+    ext_modules=[CMakeExtension("combineharvester_dummy")],
+)
 


### PR DESCRIPTION
## Summary
- build CombineTools with CMake during setup using a dummy extension
- copy the shared library into the package source and load it via an absolute path
- rename CombineTools output to libCombineHarvesterCombineTools through CMake

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -c "import CombineHarvester.CombineTools.ch"` *(fails: No module named 'CombineHarvester')*

------
https://chatgpt.com/codex/tasks/task_e_68bc7fc4eba08329a781f337e1286dd0