### PR TITLE
Explicitly pass Python executable to CMake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,14 @@ class CMakeBuild(build_ext):
         build_temp = Path(self.build_temp)
         build_temp.mkdir(parents=True, exist_ok=True)
         source_dir = Path(__file__).resolve().parent
-        subprocess.check_call(["cmake", "-S", str(source_dir), "-B", str(build_temp)])
+        subprocess.check_call([
+            "cmake",
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_temp),
+            f"-DPython3_EXECUTABLE={sys.executable}",
+        ])
         subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
 
         suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")


### PR DESCRIPTION
## Summary
- pass the running Python interpreter to CMake through `-DPython3_EXECUTABLE`

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc819221008329b1c56b17684ffffc