### PR TITLE
Use Python_EXECUTABLE in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class CMakeBuild(build_ext):
             str(source_dir),
             "-B",
             str(build_temp),
-            f"-DPython3_EXECUTABLE={sys.executable}",
+            f"-DPython_EXECUTABLE={sys.executable}",
         ])
         subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
 


### PR DESCRIPTION
## Summary
- replace Python3_EXECUTABLE with Python_EXECUTABLE in CMake configuration

## Testing
- `pip install -e .` *(fails: Could not find setuptools>=61; ProxyError)*
- `python -c "import cppyy_backend"`
- `python -c "import CombineHarvester.CombineTools.ch"` *(fails: ModuleNotFoundError: No module named 'CombineHarvester')*

------
https://chatgpt.com/codex/tasks/task_e_68bc82f8b5b083298fd8d5d74f05e56f