### PR TITLE
Set up hidden CombineHarvester staging package and adjust build

### DIFF
--- a/.python/CombineHarvester/CombineTools
+++ b/.python/CombineHarvester/CombineTools
@@ -1,0 +1,1 @@
+../../CombineTools/python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,33 +18,10 @@ dependencies = [
 pdg-round = "CombineHarvester.CombineTools.pdgRounding:main"
 ch-maketable = "CombineHarvester.CombineTools.maketable:main"
 
-[tool.setuptools]
-packages = [
-    "CombineHarvester.CombineTools",
-    "CombineHarvester.CombineTools.combine",
-    "CombineHarvester.CombineTools.systematics",
-    "CombineHarvester.CombineTools.scripts",
-    "CombineHarvester.CombineTools.input",
-    "CombineHarvester.CombineTools.input.examples",
-    "CombineHarvester.CombineTools.input.job_prefixes",
-    "CombineHarvester.CombineTools.input.xsecs_brs",
-]
-
-[tool.setuptools.package-dir]
-"CombineHarvester.CombineTools" = "CombineTools/python"
-"CombineHarvester.CombineTools.combine" = "CombineTools/python/combine"
-"CombineHarvester.CombineTools.systematics" = "CombineTools/python/systematics"
-"CombineHarvester.CombineTools.scripts" = "CombineTools/scripts"
-"CombineHarvester.CombineTools.input" = "CombineTools/input"
-"CombineHarvester.CombineTools.input.examples" = "CombineTools/input/examples"
-"CombineHarvester.CombineTools.input.job_prefixes" = "CombineTools/input/job_prefixes"
-"CombineHarvester.CombineTools.input.xsecs_brs" = "CombineTools/input/xsecs_brs"
+[tool.setuptools.packages.find]
+where = [".python"]
+include = ["CombineHarvester*"]
+exclude = ["copy_CombinedLimit*", "copy_cppyy*"]
 
 [tool.setuptools.package-data]
 "CombineHarvester.CombineTools" = ["*.so"]
-"CombineHarvester.CombineTools.scripts" = ["*"]
-"CombineHarvester.CombineTools.input" = ["*"]
-"CombineHarvester.CombineTools.input.examples" = ["*"]
-"CombineHarvester.CombineTools.input.job_prefixes" = ["*"]
-"CombineHarvester.CombineTools.input.xsecs_brs" = ["*"]
-

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ class CMakeBuild(build_ext):
         lib_name = f"libCombineHarvesterCombineTools{suffix}"
         built_lib = build_temp / "CombineTools" / lib_name
 
-        # Copy into the package source for editable installs
-        pkg_dir = source_dir / "CombineTools" / "python"
+        # Copy into the hidden staging area for editable installs
+        pkg_dir = source_dir / ".python" / "CombineHarvester" / "CombineTools"
         pkg_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(built_lib, pkg_dir / lib_name)
 


### PR DESCRIPTION
## Summary
- Add `.python` staging package with symlink to CombineTools sources
- Configure setuptools to find packages from the hidden staging area
- Copy built library into staging package and build output

## Testing
- `python setup.py egg_info` *(fails: No module named 'setuptools')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68bc861635e8832983070348f319a356