### PR TITLE
Add cppyy backend requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,12 @@
 [build-system]
-requires = ["setuptools>=61", "wheel", "cmake", "ninja"]
+requires = [
+    "setuptools>=61",
+    "wheel",
+    "cmake",
+    "ninja",
+    "cppyy-backend==1.15.3",
+    "cppyy-cling",
+]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
- require cppyy-backend and cppyy-cling for builds in pyproject configuration

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61; ProxyError 403)*
- `python -c "import CombineHarvester.CombineTools.ch"` *(fails: ModuleNotFoundError: No module named 'CombineHarvester')*

------
https://chatgpt.com/codex/tasks/task_e_68bc87e65e2c8329ac81dfd7480b52bc