### PR TITLE
Pass system CombinedLimit flags to CMake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ class CMakeBuild(build_ext):
             "-B",
             str(build_temp),
             f"-DPython_EXECUTABLE={sys.executable}",
+            "-DUSE_SYSTEM_COMBINEDLIMIT=ON",
+            f"-DCMAKE_PREFIX_PATH={sys.prefix}",
         ])
         subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
 


### PR DESCRIPTION
## Summary
- forward USE_SYSTEM_COMBINEDLIMIT and CMAKE_PREFIX_PATH to the CMake configure step so both wheel and editable builds use system CombinedLimit

## Testing
- `python -m pytest -q` (fails: No module named 'ROOT'; No module named 'six')

------
https://chatgpt.com/codex/tasks/task_e_68bc8dac97208329b6b6143a0ad5da02