### PR TITLE
Define POSIX source for CombineTools

### DIFF
--- a/CombineTools/CMakeLists.txt
+++ b/CombineTools/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 # dependencies are linked once and reused by all executables.
 add_library(CombineTools SHARED ${COMBINE_TOOLS_SRC})
 
+target_compile_definitions(CombineTools PRIVATE _POSIX_C_SOURCE=200809L)
+
 # Many sources include headers via the historic
 #   "CombineHarvester/CombineTools/interface/..." path.
 # Expose the repository root during the build so this


### PR DESCRIPTION
## Summary
- add `_POSIX_C_SOURCE=200809L` compile definition to CombineTools

## Testing
- `cmake -S . -B build` *(fails: unable to clone HiggsAnalysis-CombinedLimit due to 403 Forbidden)*
- `cmake --build build` *(fails: Makefile: No such file or directory)*
- `pip install -e .` *(fails: could not find setuptools>=61 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e56e4008329abcdfc13adf3b1fb