### PR TITLE
Reuse prebuilt CombineTools library if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import shutil
@@ -14,9 +15,37 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def build_extension(self, ext: Extension) -> None:  # noqa: D401 - see base class
+        source_dir = Path(__file__).resolve().parent
+
+        suffix = ".dll" if sys.platform == "win32" else (
+            ".dylib" if sys.platform == "darwin" else ".so"
+        )
+        lib_name = f"libCombineHarvesterCombineTools{suffix}"
+
+        search_dirs = [Path(sys.prefix) / "lib", Path(sys.prefix) / "lib64"]
+        search_dirs.extend(
+            Path(p) for p in os.environ.get("LD_LIBRARY_PATH", "").split(os.pathsep) if p
+        )
+        search_dirs.append(source_dir / ".python" / "CombineHarvester" / "CombineTools")
+
+        for directory in search_dirs:
+            candidate = directory / lib_name
+            if candidate.is_file():
+                print(f"Reusing prebuilt CombineTools at {candidate}")
+
+                pkg_dir = source_dir / ".python" / "CombineHarvester" / "CombineTools"
+                pkg_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(candidate, pkg_dir / lib_name)
+
+                dest_dir = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(candidate, dest_dir / lib_name)
+                return
+
+        print("CombineTools library not found—building from source")
+
         build_temp = Path(self.build_temp)
         build_temp.mkdir(parents=True, exist_ok=True)
-        source_dir = Path(__file__).resolve().parent
         subprocess.check_call([
             "cmake",
             "-S",
@@ -29,16 +58,12 @@ class CMakeBuild(build_ext):
         ])
         subprocess.check_call(["cmake", "--build", str(build_temp), "--target", "CombineTools"])
 
-        suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
-        lib_name = f"libCombineHarvesterCombineTools{suffix}"
         built_lib = build_temp / "CombineTools" / lib_name
 
-        # Copy into the hidden staging area for editable installs
         pkg_dir = source_dir / ".python" / "CombineHarvester" / "CombineTools"
         pkg_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(built_lib, pkg_dir / lib_name)
 
-        # Ensure the library is also available in the build directory
         dest_dir = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(built_lib, dest_dir / lib_name)


### PR DESCRIPTION
## Summary
- Check common library locations for prebuilt `libCombineHarvesterCombineTools` before invoking CMake
- Reuse and copy existing library if found, otherwise fall back to building from source
- Drop reference `copy_CombinedLimit` directories from prebuilt library search

## Testing
- `python -m py_compile setup.py`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'six')*

------
https://chatgpt.com/codex/tasks/task_e_68bc9085b2188329917d5c59b8221912