### PR TITLE
Add build thread option to CMake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ installed package:
 python -m pip install -e .
 ```
 
+To select a specific number of threads for the C++ build, include
+`--config-settings=build-threads=<N>`:
+
+```bash
+python -m pip install -e . --config-settings=build-threads=4
+```
+
 See [docs/StandaloneInstallation.md](docs/StandaloneInstallation.md) for
 more details on dependency setup and optional Conda environments. The
 current recommended tag is `v3.0.0-pre1`.


### PR DESCRIPTION
## Summary
- allow specifying `--build-threads` for the `CMakeBuild` command
- document how to select build threads during editable installs

## Testing
- `python -m py_compile setup.py`
- `python setup.py build_ext --help` *(fails: ModuleNotFoundError: No module named 'setuptools')*
- `python -m pip install setuptools` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9204c17c8329ab19738091b1763b