### PR TITLE
Remove dummy extension after CombineTools copy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,10 @@ class CMakeBuild(build_ext):
                 dest_dir = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
                 dest_dir.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(candidate, dest_dir / lib_name)
+
+                self.extensions.remove(ext)
+                if getattr(self.distribution, "ext_modules", None):
+                    self.distribution.ext_modules.remove(ext)
                 return
 
         print("CombineTools library not found—building from source")
@@ -90,6 +94,11 @@ class CMakeBuild(build_ext):
         dest_dir = Path(self.build_lib) / "CombineHarvester" / "CombineTools"
         dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(built_lib, dest_dir / lib_name)
+
+        self.extensions.remove(ext)
+        if getattr(self.distribution, "ext_modules", None):
+            self.distribution.ext_modules.remove(ext)
+        return
 
 
 setup(


### PR DESCRIPTION
## Summary
- Remove `combineharvester_dummy` extension after copying prebuilt or built CombineTools library to avoid extra copy step.

## Testing
- `python -m py_compile setup.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT')*

------
https://chatgpt.com/codex/tasks/task_e_68bc94c8a0208329bf6be14867e5772c