### PR TITLE
Use importlib resources files with fallback

### DIFF
--- a/CombineTools/python/ch.py
+++ b/CombineTools/python/ch.py
@@ -9,15 +9,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 import itertools
 from os import environ
-from importlib import resources
 import sys
+
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files  # backport for Python < 3.9
 
 # Prevent cppyy's check for the PCH
 environ['CLING_STANDARD_PCH'] = 'none'
 import cppyy
 
 suffix = ".dll" if sys.platform == "win32" else (".dylib" if sys.platform == "darwin" else ".so")
-lib_path = resources.files(__package__) / f"libCombineHarvesterCombineTools{suffix}"
+lib_path = files(__package__) / f"libCombineHarvesterCombineTools{suffix}"
 cppyy.load_reflection_info(str(lib_path))
 AutoRebin = cppyy.gbl.ch.AutoRebin
 BinByBinFactory = cppyy.gbl.ch.BinByBinFactory

--- a/CombineTools/python/combine/CombineToolBase.py
+++ b/CombineTools/python/combine/CombineToolBase.py
@@ -4,7 +4,6 @@ import stat
 import shutil
 from functools import partial
 from multiprocessing import Pool
-from importlib import resources
 import CombineHarvester.CombineTools.ch as ch
 
 DRY_RUN = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "cppyy",
+    'importlib_resources; python_version < "3.9"',
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- load CombineTools shared library via `importlib.resources.files` with fallback to `importlib_resources`
- add `importlib_resources` conditional dependency
- drop unused `importlib` import in CombineToolBase

## Testing
- `python -m py_compile CombineTools/python/ch.py CombineTools/python/combine/CombineToolBase.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ROOT')*


------
https://chatgpt.com/codex/tasks/task_e_68bc96506a408329b0df5005049a6ee9